### PR TITLE
Remove Deno formatter check from CI

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -44,8 +44,6 @@ jobs:
       - name: Validate package exports
         run: deno eval 'import "./src/BetterConsoleGroup.ts"'
 
-      - run: deno fmt --check
-
       - run: deno lint
 
       - name: Validate JSR package version with NPM package version


### PR DESCRIPTION
## Summary

- remove `deno fmt --check` from the regular Deno CI workflow
- keep Deno CI focused on Deno compatibility checks: install, package export import, lint, and package/JSR version equality
- leave JSR publishing unchanged so published artifacts continue to match the checked-out git tag/ref

## Root Cause

PR #236 updated Prettier, and Prettier now formats `src/asyncGroup.ts` differently from `deno fmt`. The repo source is intentionally Prettier-owned, so asserting `deno fmt --check` on tracked source makes the Deno and Node formatter checks fight.

## Release Follow-up

If JSR needs Deno-formatted source, that should happen in the release flow by creating a release-only Deno-formatted commit and tagging that commit, while pushing only the version bump commit to `main`. That keeps `main` Prettier-owned and keeps JSR provenance tied to a clean tag.

## Validation

- `yarn format && yarn lint --fix && yarn build && yarn flow && yarn test`
- `deno eval 'import "./src/BetterConsoleGroup.ts"'`
- `deno lint`
- package/JSR version equality check